### PR TITLE
feat: Paging Library 적용

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -49,8 +49,4 @@ dependencies {
     //Retrofit2
     implementation(Dependencies.Network.retrofit)
     implementation(Dependencies.Network.retrofitGson)
-
-    //Paging3
-    implementation (Dependencies.Paging.paging)
-    implementation (Dependencies.Paging.pagingKtx)
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -49,4 +49,8 @@ dependencies {
     //Retrofit2
     implementation(Dependencies.Network.retrofit)
     implementation(Dependencies.Network.retrofitGson)
+
+    //Paging3
+    implementation (Dependencies.Paging.paging)
+    implementation (Dependencies.Paging.pagingKtx)
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     //Flow
     implementation(Dependencies.Coroutines.core)
 
-    //Retrofit2
-    implementation(Dependencies.Network.retrofit)
-    implementation(Dependencies.Network.retrofitGson)
+    //Paging3
+    implementation (Dependencies.Paging.paging)
+    implementation (Dependencies.Paging.pagingKtx)
 }

--- a/domain/src/main/java/com/zzu/afreecatv/domain/paging/BroadPagingSource.kt
+++ b/domain/src/main/java/com/zzu/afreecatv/domain/paging/BroadPagingSource.kt
@@ -4,6 +4,7 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.zzu.afreecatv.data.datasource.broad.BroadDataSource
 import com.zzu.afreecatv.data.dto.BroadDto
+import kotlinx.coroutines.delay
 
 class BroadPagingSource(
     private val broadDataSource: BroadDataSource,
@@ -22,6 +23,8 @@ class BroadPagingSource(
             val page = params.key ?: 1
 
             val item = broadDataSource.getBroadListByCategoryNo(query, page)
+
+            if(page != 1) delay(500L)
 
             LoadResult.Page(
                 data = item,

--- a/domain/src/main/java/com/zzu/afreecatv/domain/paging/BroadPagingSource.kt
+++ b/domain/src/main/java/com/zzu/afreecatv/domain/paging/BroadPagingSource.kt
@@ -1,0 +1,37 @@
+package com.zzu.afreecatv.domain.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.zzu.afreecatv.data.datasource.broad.BroadDataSource
+import com.zzu.afreecatv.data.dto.BroadDto
+
+class BroadPagingSource(
+    private val broadDataSource: BroadDataSource,
+    private val query: String,
+) : PagingSource<Int, BroadDto>() {
+
+    override fun getRefreshKey(state: PagingState<Int, BroadDto>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            val anchorPage = state.closestPageToPosition(anchorPosition)
+            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+        }
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, BroadDto> {
+        return try {
+            val page = params.key ?: 1
+
+            val item = broadDataSource.getBroadListByCategoryNo(query, page)
+
+            LoadResult.Page(
+                data = item,
+                prevKey = if (page == 1) null else page - 1,
+                nextKey = if (item.isEmpty()) null else page + 1
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        } catch (e: Throwable) {
+            LoadResult.Error(e)
+        }
+    }
+}

--- a/domain/src/main/java/com/zzu/afreecatv/domain/repository/broad/BroadRepository.kt
+++ b/domain/src/main/java/com/zzu/afreecatv/domain/repository/broad/BroadRepository.kt
@@ -1,11 +1,13 @@
 package com.zzu.afreecatv.domain.repository.broad
 
+import androidx.paging.PagingData
 import com.zzu.afreecatv.domain.model.Broad
 import com.zzu.afreecatv.domain.model.Category
+import kotlinx.coroutines.flow.Flow
 
 interface BroadRepository {
 
     suspend fun getAllBroadList(pageNo: Int): List<Broad>
-    suspend fun getBroadListByCategoryNo(categoryNo: String, pageNo: Int): List<Broad>
+    suspend fun getBroadListByCategoryNo(categoryNo: String, size: Int): Flow<PagingData<Broad>>
     suspend fun getBroadCategoryList(): List<Category>
 }

--- a/domain/src/main/java/com/zzu/afreecatv/domain/repository/broad/impl/BroadRepositoryImpl.kt
+++ b/domain/src/main/java/com/zzu/afreecatv/domain/repository/broad/impl/BroadRepositoryImpl.kt
@@ -1,10 +1,17 @@
 package com.zzu.afreecatv.domain.repository.broad.impl
 
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.map
 import com.zzu.afreecatv.data.datasource.broad.BroadDataSource
+import com.zzu.afreecatv.domain.paging.BroadPagingSource
 import com.zzu.afreecatv.domain.mapper.toModel
 import com.zzu.afreecatv.domain.model.Broad
 import com.zzu.afreecatv.domain.model.Category
 import com.zzu.afreecatv.domain.repository.broad.BroadRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class BroadRepositoryImpl @Inject constructor(
@@ -14,8 +21,17 @@ class BroadRepositoryImpl @Inject constructor(
     override suspend fun getAllBroadList(pageNo: Int): List<Broad> =
         broadDataSource.getAllBroadList(pageNo).broad.map { it.toModel() }
 
-    override suspend fun getBroadListByCategoryNo(categoryNo: String, pageNo: Int): List<Broad> =
-        broadDataSource.getBroadListByCategoryNo(categoryNo, pageNo).map { it.toModel() }
+    override suspend fun getBroadListByCategoryNo(
+        categoryNo: String,
+        size: Int
+    ): Flow<PagingData<Broad>> =
+        Pager(
+            config = PagingConfig(
+                pageSize = size,
+                initialLoadSize = size,
+                enablePlaceholders = false
+            ), pagingSourceFactory = { BroadPagingSource(broadDataSource, categoryNo) }
+        ).flow.map { it.map { item -> item.toModel() } }
 
     override suspend fun getBroadCategoryList(): List<Category> =
         broadDataSource.getBroadCategoryList().map { it.toModel() }

--- a/domain/src/main/java/com/zzu/afreecatv/domain/usecase/broad/GetBroadListByCategoryNoUseCase.kt
+++ b/domain/src/main/java/com/zzu/afreecatv/domain/usecase/broad/GetBroadListByCategoryNoUseCase.kt
@@ -1,8 +1,10 @@
 package com.zzu.afreecatv.domain.usecase.broad
 
+import androidx.paging.PagingData
 import com.zzu.afreecatv.domain.model.Broad
+import kotlinx.coroutines.flow.Flow
 
 interface GetBroadListByCategoryNoUseCase {
 
-    suspend operator fun invoke(categoryNo: String, pageNo: Int = 1): Result<List<Broad>>
+    suspend operator fun invoke(categoryNo: String, size: Int = 1): Flow<PagingData<Broad>>
 }

--- a/domain/src/main/java/com/zzu/afreecatv/domain/usecase/broad/impl/GetBroadListByCategoryNoUseCaseImpl.kt
+++ b/domain/src/main/java/com/zzu/afreecatv/domain/usecase/broad/impl/GetBroadListByCategoryNoUseCaseImpl.kt
@@ -1,8 +1,10 @@
 package com.zzu.afreecatv.domain.usecase.broad.impl
 
+import androidx.paging.PagingData
 import com.zzu.afreecatv.domain.model.Broad
 import com.zzu.afreecatv.domain.repository.broad.BroadRepository
 import com.zzu.afreecatv.domain.usecase.broad.GetBroadListByCategoryNoUseCase
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 
@@ -10,6 +12,6 @@ class GetBroadListByCategoryNoUseCaseImpl @Inject constructor(
     private val broadRepository: BroadRepository
 ) : GetBroadListByCategoryNoUseCase {
 
-    override suspend operator fun invoke(categoryNo: String, pageNo: Int): Result<List<Broad>> =
-        runCatching { broadRepository.getBroadListByCategoryNo(categoryNo, pageNo) }
+    override suspend operator fun invoke(categoryNo: String, size: Int): Flow<PagingData<Broad>> =
+        broadRepository.getBroadListByCategoryNo(categoryNo, size)
 }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -62,19 +62,12 @@ dependencies {
     //Coil
     implementation (Dependencies.Coil.coil)
 
-    //Retrofit2
-    implementation (Dependencies.Network.retrofit)
-    implementation (Dependencies.Network.retrofitGson)
-
     implementation (Dependencies.Androidx.recyclerView)
 
     //ktx
     implementation (Dependencies.Androidx.activityKtx)
     implementation (Dependencies.Androidx.fragmentKtx)
     implementation (Dependencies.Androidx.viewModelKtx)
-
-    //SwipeRefreshLayout
-    implementation (Dependencies.Androidx.swipeRefreshLayout)
 
     //Paging3
     implementation (Dependencies.Paging.paging)

--- a/ui/src/main/java/com/zzu/afreecatv/ui/home/broad/BroadListFragment.kt
+++ b/ui/src/main/java/com/zzu/afreecatv/ui/home/broad/BroadListFragment.kt
@@ -14,8 +14,9 @@ import com.zzu.afreecatv.domain.model.Broad
 import com.zzu.afreecatv.ui.detail.DetailFragment
 import com.zzu.afreecatv.ui.home.broad.adapter.BroadRVAdapter
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class BroadListFragment : Fragment() {
@@ -47,9 +48,9 @@ class BroadListFragment : Fragment() {
     }
 
     private fun initObserver() {
-        viewModel.broadList.onEach {
-            broadRVAdapter.submitList(it)
-        }.launchIn(this.lifecycleScope)
+        lifecycleScope.launch(Dispatchers.IO) {
+            viewModel.broadList.collectLatest { broadRVAdapter.submitData(it) }
+        }
     }
 
     private fun initRecyclerView() {

--- a/ui/src/main/java/com/zzu/afreecatv/ui/home/broad/BroadListFragment.kt
+++ b/ui/src/main/java/com/zzu/afreecatv/ui/home/broad/BroadListFragment.kt
@@ -5,9 +5,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.paging.LoadState
 import com.zzu.afreecatv.R
 import com.zzu.afreecatv.databinding.FragmentBroadListBinding
 import com.zzu.afreecatv.domain.model.Broad
@@ -16,6 +18,8 @@ import com.zzu.afreecatv.ui.home.broad.adapter.BroadRVAdapter
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -51,6 +55,10 @@ class BroadListFragment : Fragment() {
         lifecycleScope.launch(Dispatchers.IO) {
             viewModel.broadList.collectLatest { broadRVAdapter.submitData(it) }
         }
+        broadRVAdapter.loadStateFlow.onEach {
+            binding?.piPrepend?.isVisible = it.source.prepend is LoadState.Loading
+            binding?.piAppend?.isVisible = it.source.append is LoadState.Loading
+        }.launchIn(this.lifecycleScope)
     }
 
     private fun initRecyclerView() {

--- a/ui/src/main/java/com/zzu/afreecatv/ui/home/broad/BroadListViewModel.kt
+++ b/ui/src/main/java/com/zzu/afreecatv/ui/home/broad/BroadListViewModel.kt
@@ -2,9 +2,12 @@ package com.zzu.afreecatv.ui.home.broad
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import com.zzu.afreecatv.domain.model.Broad
 import com.zzu.afreecatv.domain.usecase.broad.GetBroadListByCategoryNoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -15,20 +18,16 @@ class BroadListViewModel @Inject constructor(
     private val getBroadListByCategoryNoUseCase: GetBroadListByCategoryNoUseCase
 ) : ViewModel() {
 
-    private val _broadList = MutableStateFlow<List<Broad>>(emptyList())
-    val broadList: StateFlow<List<Broad>> = _broadList
+    private val _broadList = MutableStateFlow<PagingData<Broad>>(PagingData.empty())
+    val broadList: StateFlow<PagingData<Broad>> = _broadList
 
     lateinit var categoryNo: String
 
-    private var pageNo = 1
-
-    fun fetchBroadList(pageNo: Int = this.pageNo) {
-        viewModelScope.launch {
-            getBroadListByCategoryNoUseCase(categoryNo, pageNo)
-                .onSuccess {
-                    val prev = broadList.value
-                    _broadList.emit(prev + it)
-                }
+    fun fetchBroadList(size: Int = 60) {
+        viewModelScope.launch(Dispatchers.IO) {
+            getBroadListByCategoryNoUseCase(categoryNo, size)
+                .cachedIn(viewModelScope)
+                .collect { _broadList.emit(it) }
         }
     }
 }

--- a/ui/src/main/java/com/zzu/afreecatv/ui/home/broad/adapter/BroadRVAdapter.kt
+++ b/ui/src/main/java/com/zzu/afreecatv/ui/home/broad/adapter/BroadRVAdapter.kt
@@ -2,19 +2,19 @@ package com.zzu.afreecatv.ui.home.broad.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
 import com.zzu.afreecatv.databinding.ItemBroadBinding
 import com.zzu.afreecatv.domain.model.Broad
 import com.zzu.afreecatv.ui.home.broad.viewholder.BroadViewHolder
 
 class BroadRVAdapter :
-    ListAdapter<Broad, BroadViewHolder>(diffUtil) {
+    PagingDataAdapter<Broad, BroadViewHolder>(diffUtil) {
 
     lateinit var listener: OnClickListener
 
     override fun onBindViewHolder(holder: BroadViewHolder, position: Int) {
-        holder.bind(getItem(position), listener)
+        getItem(position)?.let { holder.bind(it, listener) }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BroadViewHolder {

--- a/ui/src/main/res/layout/fragment_broad_list.xml
+++ b/ui/src/main/res/layout/fragment_broad_list.xml
@@ -17,20 +17,31 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toTopOf="@id/pb_loading"
+            app:layout_constraintBottom_toTopOf="@id/pi_append"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/pi_prepend"
             tools:listitem="@layout/item_broad" />
 
-        <ProgressBar
-            android:id="@+id/pb_loading"
-            android:layout_width="wrap_content"
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/pi_prepend"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:indeterminate="true"
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent" />
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/pi_append"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
### ❗️ 이슈
- close #15 

### 📝 구현한 내용
- Paging library 적용
- 불필요한 gradle 정리
   - retrofit2 등
- paging 로딩 중일 때 Linear Indicator로 표시함

### ❓ 고민한 내용
- BroadPagingSource의 위치
   - PagingSource를 보고 Data와 domain Module 중 어디에 위치하는 것이 옳은 일인가를 고민했다.
   - PagingSource은 다음 페이지를 로드하고 이를 관리해주는 추상화된 계층으로 볼 수 있다.
   - 즉, UI와 Data 계층 간에 추상화된 계층으로 Domain Layer에 더 적합다고 생각이 들어 이를 위치했다.
   - ![참고](https://developer.android.com/static/codelabs/android-paging-basics/img/566d0f6506f39480_856.jpeg)
